### PR TITLE
:heavy_plus_sign: Added Include to Adafruit_I2CDevice

### DIFF
--- a/src/hiveeyes-epaper.ino
+++ b/src/hiveeyes-epaper.ino
@@ -32,6 +32,7 @@
 #include "forecast_record.h"
 #include "hive_record.h"
 #include "apicast_record.h"
+#include <Adafruit_I2CDevice.h>
 
 //#include "lang.h"
 //#include "lang_cz.h"                // Localisation (Czech)


### PR DESCRIPTION
Dies behebt das Problem bei der Kompilierung siehe dazu auch #3 